### PR TITLE
fix: gluestack-related alert and modal ui issues

### DIFF
--- a/client/app/(admin)/lottery.tsx
+++ b/client/app/(admin)/lottery.tsx
@@ -16,7 +16,7 @@ import EmptyAlert from "@/components/custom-empty-alert";
 import FortuneWheel from "@/components/custom-fortune-wheel";
 import CustomSpinner from "@/components/custom-spinner";
 
-import { Button, ButtonText } from "@/components/ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Heading } from "@/components/ui/heading";
 import { HStack } from "@/components/ui/hstack";
 import { VStack } from "@/components/ui/vstack";

--- a/client/app/(admin)/screensaver.tsx
+++ b/client/app/(admin)/screensaver.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Heading } from "@/components/ui/heading";
-import { Button, ButtonText, ButtonIcon } from "@/components/ui/button";
+import { Button, ButtonText, ButtonIcon } from "@/components/button";
 import { VStack } from "@/components/ui/vstack";
 import { HStack } from "@/components/ui/hstack";
 import { Card } from "@/components/ui/card";
@@ -258,13 +258,13 @@ export default function ScreensaverManager() {
                     {/* Actions */}
                     <VStack space="xs">
                       <Button
-                        size="sm"
+                        action="negative"
                         variant="outline"
-                        className="border-red-600"
+                        size="sm"
                         onPress={() => handleDeleteImage(image.id)}
                       >
-                        <ButtonIcon as={Trash2} className="text-red-600" />
-                        <ButtonText className="text-red-600">Delete</ButtonText>
+                        <ButtonIcon as={Trash2} className="text-destructive" />
+                        <ButtonText className="text-destructive">Delete</ButtonText>
                       </Button>
                     </VStack>
                   </HStack>

--- a/client/app/(admin)/users/index.tsx
+++ b/client/app/(admin)/users/index.tsx
@@ -10,7 +10,7 @@ import api from "@/utils/api";
 
 import { VStack } from "@/components/ui/vstack";
 import { HStack } from "@/components/ui/hstack";
-import { Button, ButtonText, ButtonIcon } from "@/components/ui/button";
+import { Button, ButtonText, ButtonIcon } from "@/components/button";
 import { Input, InputField } from "@/components/ui/input";
 import { Heading } from "@/components/ui/heading";
 import { Icon } from "@/components/ui/icon";

--- a/client/app/(admin)/voucher-management/index.tsx
+++ b/client/app/(admin)/voucher-management/index.tsx
@@ -5,7 +5,7 @@ import { Plus, X, Pencil, Download, Trash, Check, Tag, Gift, Star, Award, Heart,
 import api from "@/utils/api";
 import { VStack } from "@/components/ui/vstack";
 import { HStack } from "@/components/ui/hstack";
-import { Button, ButtonText, ButtonIcon } from "@/components/ui/button";
+import { Button, ButtonText, ButtonIcon } from "@/components/button";
 import { Input, InputField } from "@/components/ui/input";
 import { Heading } from "@/components/ui/heading";
 import { Icon } from "@/components/ui/icon";

--- a/client/app/(public)/catalogue/[id].tsx
+++ b/client/app/(public)/catalogue/[id].tsx
@@ -13,7 +13,7 @@ import Spinner from "@/components/custom-spinner";
 
 import * as alert from "@/components/ui/alert-dialog";
 import { Badge, BadgeText } from "@/components/ui/badge";
-import { Button, ButtonIcon, ButtonText } from "@/components/ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { Heading } from "@/components/ui/heading";
 import { HStack } from "@/components/ui/hstack";

--- a/client/app/(public)/catalogue/index.tsx
+++ b/client/app/(public)/catalogue/index.tsx
@@ -18,7 +18,7 @@ import { HStack } from "@/components/ui/hstack";
 import * as slider from "@/components/ui/slider";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
-import { Button, ButtonText, ButtonIcon } from "@/components/ui/button";
+import { Button, ButtonText, ButtonIcon } from "@/components/button";
 
 const CataloguePage: React.FC = () => {
   const router = useRouter();

--- a/client/app/(public)/feedback/product-request.tsx
+++ b/client/app/(public)/feedback/product-request.tsx
@@ -3,7 +3,7 @@ import { KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import { ChevronLeft, ChevronDown } from "lucide-react-native";
 
-import { Button, ButtonIcon, ButtonText } from "@/components/ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { Input, InputField } from "@/components/ui/input";
 import {
@@ -141,8 +141,7 @@ const ProductRequestPage: React.FC = () => {
             )}
 
             <Button
-              action="primary"
-              className="bg-redscale-500"
+              action="negative"
               onPress={handleSubmit}
               disabled={submitting}
             >

--- a/client/app/(public)/feedback/rate-us.tsx
+++ b/client/app/(public)/feedback/rate-us.tsx
@@ -1,5 +1,5 @@
 import SmileyRating from "@/components/custom-smiley-rating";
-import { Button, ButtonIcon, ButtonText } from "@/components/ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { Input, InputField } from "@/components/ui/input";
 import {
@@ -139,8 +139,7 @@ const RateUsPage: React.FC = () => {
             )}
 
             <Button
-              action="primary"
-              className="bg-redscale-500"
+              action="negative"
               onPress={handleSubmit}
               disabled={submitting}
             >

--- a/client/app/(public)/index.tsx
+++ b/client/app/(public)/index.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "expo-router";
 import { Users, ChevronLeft, ChevronRight, HeartHandshake, HandHeart } from "lucide-react-native";
 
 import { Box } from "@/components/ui/box";
-import { Button, ButtonText } from "@/components/ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { Heading } from "@/components/ui/heading";
 import { HStack } from "@/components/ui/hstack";

--- a/client/app/(public)/login.tsx
+++ b/client/app/(public)/login.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import AdminLoginForm from "@/components/login/admin-login";
 import ResidentLoginForm from "@/components/login/resident-login";
-import { Button, ButtonText } from "@/components/ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { HStack } from "@/components/ui/hstack";
 import { ImageBackground } from "@/components/ui/image-background";

--- a/client/app/(public)/vouchers/[id].tsx
+++ b/client/app/(public)/vouchers/[id].tsx
@@ -11,7 +11,7 @@ import Spinner from "@/components/custom-spinner";
 
 import * as alert from "@/components/ui/alert-dialog";
 import { Badge, BadgeText } from "@/components/ui/badge";
-import { Button, ButtonIcon, ButtonText } from "@/components/ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { Center } from "@/components/ui/center";
 import { Heading } from "@/components/ui/heading";
 import { HStack } from "@/components/ui/hstack";

--- a/client/app/_layout.tsx
+++ b/client/app/_layout.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "expo-router";
 import "react-native-reanimated";
-import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
+import { GluestackUIProvider } from "@/components/GluestackUIProvider";
 import "@/global.css";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { AuthProvider } from "@/contexts/auth-context";

--- a/client/components/GluestackUIProvider.tsx
+++ b/client/components/GluestackUIProvider.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from "react";
+import { View, type ViewProps } from "react-native";
+import { vars } from "nativewind";
+import { useColorScheme } from "nativewind";
+import { OverlayProvider } from "@gluestack-ui/core/overlay/creator";
+import { ToastProvider } from "@gluestack-ui/core/toast/creator";
+import { themeTokens, type ThemeMode } from "@/theme/tokens";
+
+const nativewindTheme = {
+  light: vars(themeTokens.light),
+  dark: vars(themeTokens.dark),
+};
+
+export function GluestackUIProvider({
+  mode = "light",
+  ...props
+}: {
+  mode?: ThemeMode | "system";
+  children?: React.ReactNode;
+  style?: ViewProps["style"];
+}) {
+  const { colorScheme, setColorScheme } = useColorScheme();
+
+  useEffect(() => {
+    setColorScheme(mode);
+  }, [mode, setColorScheme]);
+
+  const resolvedScheme = colorScheme === "dark" ? "dark" : "light";
+
+  return (
+    <View
+      style={[
+        nativewindTheme[resolvedScheme],
+        { flex: 1, height: "100%", width: "100%" },
+        props.style,
+      ]}
+    >
+      <OverlayProvider>
+        <ToastProvider>{props.children}</ToastProvider>
+      </OverlayProvider>
+    </View>
+  );
+}

--- a/client/components/button.tsx
+++ b/client/components/button.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import {
+  Button as GluestackButton,
+  ButtonText as GluestackButtonText,
+  ButtonIcon as GluestackButtonIcon,
+  ButtonSpinner as GluestackButtonSpinner,
+  ButtonGroup as GluestackButtonGroup,
+} from "@/components/ui/button";
+
+type GluestackButtonProps = React.ComponentProps<typeof GluestackButton>;
+type ButtonVariant = NonNullable<GluestackButtonProps["variant"]>;
+
+export type ButtonAction = "primary" | "secondary" | "negative" | "positive";
+
+type ButtonProps = Omit<GluestackButtonProps, "action"> & {
+  action?: ButtonAction;
+  /** Filled / selected state (e.g. active nav tab). */
+  active?: boolean;
+};
+
+type StyleConfig = {
+  variant: ButtonVariant;
+  className?: string;
+};
+
+/**
+ * Default action → Gluestack variant mapping.
+ * className overrides generated hover styles (outline/ghost use bg-muted otherwise).
+ */
+const defaultActionStyles: Record<ButtonAction, StyleConfig> = {
+  primary: { variant: "default" },
+  secondary: {
+    variant: "outline",
+    className:
+      "data-[hover=true]:bg-accent data-[active=true]:bg-accent",
+  },
+  negative: {
+    variant: "destructive",
+    className:
+      "data-[hover=true]:bg-destructive/90 data-[active=true]:bg-destructive/90",
+  },
+  positive: {
+    variant: "default",
+    className:
+      "bg-greenscale-700 data-[hover=true]:bg-greenscale-900 data-[active=true]:bg-greenscale-900",
+  },
+};
+
+/** Styles when an action is paired with a non-default variant. */
+const actionVariantStyles: Partial<
+  Record<ButtonAction, Partial<Record<ButtonVariant, StyleConfig>>>
+> = {
+  primary: {
+    outline: {
+      variant: "outline",
+      className:
+        "border-indigoscale-900 data-[hover=true]:bg-indigoscale-100 data-[active=true]:bg-indigoscale-100",
+    },
+  },
+  negative: {
+    outline: {
+      variant: "outline",
+      className:
+        "border-destructive data-[hover=true]:bg-destructive/10 data-[active=true]:bg-destructive/10",
+    },
+  },
+  secondary: {
+    link: { variant: "link" },
+  },
+};
+
+/** Extra classes when `active` is true (e.g. selected nav tab). */
+const activeActionStyles: Partial<
+  Record<ButtonAction, Partial<Record<ButtonVariant, string>>>
+> = {
+  primary: {
+    outline:
+      "bg-indigoscale-700 border-indigoscale-900 data-[hover=true]:bg-indigoscale-900 data-[active=true]:bg-indigoscale-900",
+  },
+  negative: {
+    outline:
+      "bg-destructive border-destructive data-[hover=true]:bg-destructive/90 data-[active=true]:bg-destructive/90",
+  },
+};
+
+function joinClasses(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function resolveButtonStyles(
+  action?: ButtonAction,
+  variant?: ButtonVariant,
+  active?: boolean,
+): StyleConfig {
+  if (!action) {
+    return { variant: variant ?? "default" };
+  }
+
+  const defaultStyle = defaultActionStyles[action];
+  const resolvedVariant = variant ?? defaultStyle.variant;
+
+  let config: StyleConfig;
+  if (variant && variant !== defaultStyle.variant) {
+    config = actionVariantStyles[action]?.[variant] ?? {
+      variant: resolvedVariant,
+    };
+  } else {
+    config = defaultStyle;
+  }
+
+  const activeClassName = active
+    ? activeActionStyles[action]?.[config.variant]
+    : undefined;
+
+  return {
+    variant: config.variant,
+    className: joinClasses(config.className, activeClassName),
+  };
+}
+
+export const Button = React.forwardRef<
+  React.ElementRef<typeof GluestackButton>,
+  ButtonProps
+>(function Button({ action, active, variant, className, ...props }, ref) {
+  const resolved = resolveButtonStyles(action, variant, active);
+
+  return (
+    <GluestackButton
+      ref={ref}
+      variant={resolved.variant}
+      className={joinClasses(resolved.className, className)}
+      {...props}
+    />
+  );
+});
+
+Button.displayName = "Button";
+
+export const ButtonText = GluestackButtonText;
+export const ButtonIcon = GluestackButtonIcon;
+export const ButtonSpinner = GluestackButtonSpinner;
+export const ButtonGroup = GluestackButtonGroup;

--- a/client/components/cart-modal.tsx
+++ b/client/components/cart-modal.tsx
@@ -6,7 +6,7 @@ import { useCart } from "@/contexts/cart-context";
 import { useAuth } from "@/contexts/auth-context";
 import api from "@/utils/api";
 
-import { Button, ButtonText } from "@/components/ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { HStack } from "@/components/ui/hstack";
 import { VStack } from "@/components/ui/vstack";
 import { Text } from "@/components/ui/text";

--- a/client/components/custom-searchable-grid.tsx
+++ b/client/components/custom-searchable-grid.tsx
@@ -6,7 +6,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import EmptyAlert from "./custom-empty-alert";
 import SearchBar from "./custom-searchbar";
 
-import { Button, ButtonText, ButtonIcon } from "./ui/button";
+import { Button, ButtonText, ButtonIcon } from "@/components/button";
 import { Card } from "./ui/card";
 import { Center } from "./ui/center";
 import { Grid, GridItem } from "./ui/grid";

--- a/client/components/dialogue/custom-discard-dialogue.tsx
+++ b/client/components/dialogue/custom-discard-dialogue.tsx
@@ -1,5 +1,5 @@
 import * as alert from "../ui/alert-dialog";
-import { Button, ButtonText } from "../ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Heading } from "../ui/heading";
 import { Text } from "../ui/text";
 

--- a/client/components/dialogue/custom-error-dialogue.tsx
+++ b/client/components/dialogue/custom-error-dialogue.tsx
@@ -1,5 +1,5 @@
 import * as alert from "../ui/alert-dialog";
-import { Button, ButtonText } from "../ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Heading } from "../ui/heading";
 import { Text } from "../ui/text";
 

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -17,7 +17,7 @@ import { VStack } from "../ui/vstack";
 import { Text } from "../ui/text";
 import { Heading } from "../ui/heading";
 import { Pressable } from "../ui/pressable";
-import { Button, ButtonIcon, ButtonText } from "../ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { Divider } from "../ui/divider";
 import { useWindowDimensions } from "react-native";
 
@@ -161,16 +161,9 @@ const Header: React.FC = () => {
                 <Button
                   key={tab.name}
                   onPress={() => handleTabPress(tab)}
-                  className={
-                    isAuthButton
-                      ? isActive
-                        ? "bg-redscale-500 border-redscale-700 data-[hover=true]:border-redscale-700"
-                        : "border-redscale-700 data-[hover=true]:border-redscale-700"
-                      : isActive
-                        ? "bg-indigoscale-700 border-indigoscale-900"
-                        : "border-indigoscale-900"
-                  }
+                  action={isAuthButton ? "negative" : "primary"}
                   variant="outline"
+                  active={isActive}
                   size="sm"
                 >
                   <ButtonIcon
@@ -179,10 +172,10 @@ const Header: React.FC = () => {
                       isAuthButton
                         ? isActive
                           ? "text-white"
-                          : "text-redscale-500" // redscale-500
+                          : "text-destructive"
                         : isActive
                           ? "text-white"
-                          : "text-indigoscale-700" // indigoscale-700
+                          : "text-indigoscale-700"
                     }
                   />
                   {!isCompact && (
@@ -190,11 +183,11 @@ const Header: React.FC = () => {
                       className={
                         isAuthButton
                           ? isActive
-                            ? "text-white text-md data-[hover=true]:text-redscale-500"
-                            : "text-redscale-500 text-md data-[hover=true]:text-redscale-500"
+                            ? "text-white text-md"
+                            : "text-destructive text-md"
                           : isActive
-                            ? "text-white text-md data-[hover=true]:text-indigoscale-700"
-                            : "text-indigoscale-700 text-md data-[hover=true]:text-indigoscale-700"
+                            ? "text-white text-md"
+                            : "text-indigoscale-700 text-md"
                       }
                     >
                       {tab.name}

--- a/client/components/login/admin-login.tsx
+++ b/client/components/login/admin-login.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { useAuth } from "@/contexts/auth-context";
 
-import { Button, ButtonIcon, ButtonText } from "../ui/button";
+import { Button, ButtonIcon, ButtonText } from "@/components/button";
 import { FormControl, FormControlError, FormControlErrorText } from "../ui/form-control";
 import { HStack } from "../ui/hstack";
 import { Icon } from "../ui/icon";

--- a/client/components/login/resident-login.tsx
+++ b/client/components/login/resident-login.tsx
@@ -20,7 +20,7 @@ import {
   ModalContent,
   ModalFooter,
 } from "../ui/modal";
-import { Button, ButtonText } from "../ui/button";
+import { Button, ButtonText } from "@/components/button";
 import { Input, InputField, InputIcon, InputSlot } from "../ui/input";
 import { useAuth } from "@/contexts/auth-context";
 import { useRouter } from "expo-router";

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -19,10 +19,30 @@ module.exports = {
       pattern:
         /(bg|border|text|stroke|fill)-(indigoscale|redscale|orangescale|yellowscale|greenscale|bluescale|purplescale)-(100|300|500|700|900)/,
     },
+    {
+      pattern:
+        /(bg|border|text|stroke|fill)-(background|card|foreground|border|muted|destructive|accent|popover)(\/(80|90|10))?/,
+    },
   ],
   theme: {
     extend: {
       colors: {
+        /* Gluestack-style color aliases (used by generated components) */
+        foreground: "rgb(var(--foreground, 23 23 23) / <alpha-value>)",
+        card: "rgb(var(--card, 255 255 255) / <alpha-value>)",
+        "card-foreground": "rgb(var(--foreground, 23 23 23) / <alpha-value>)",
+        border: "rgb(var(--border, 229 229 229) / <alpha-value>)",
+        input: "rgb(var(--input, 229 229 229) / <alpha-value>)",
+        destructive: "rgb(var(--destructive, 213 69 42) / <alpha-value>)",
+        muted: "rgb(var(--muted, 245 245 245) / <alpha-value>)",
+        "muted-foreground": "rgb(var(--muted-foreground, 115 115 115) / <alpha-value>)",
+        accent: "rgb(var(--accent, 245 245 245) / <alpha-value>)",
+        "accent-foreground": "rgb(var(--accent-foreground, 23 23 23) / <alpha-value>)",
+        ring: "rgb(var(--ring, 103 130 203) / <alpha-value>)",
+        popover: "rgb(var(--popover, 255 255 255) / <alpha-value>)",
+        "popover-foreground": "rgb(var(--popover-foreground, 10 10 10) / <alpha-value>)",
+
+        /* MWH Color scales */
         indigoscale: {
           100: "#D9E0F2", // lightest
           300: "#A0B1DF",
@@ -60,7 +80,25 @@ module.exports = {
           500: "#852AD5",
           700: "#43156B",
         },
+
+        /* Tailwind color system (extended palette) */
+        "primary-scale": {
+          0: "rgb(var(--color-primary-0)/<alpha-value>)",
+          50: "rgb(var(--color-primary-50)/<alpha-value>)",
+          100: "rgb(var(--color-primary-100)/<alpha-value>)",
+          200: "rgb(var(--color-primary-200)/<alpha-value>)",
+          300: "rgb(var(--color-primary-300)/<alpha-value>)",
+          400: "rgb(var(--color-primary-400)/<alpha-value>)",
+          500: "rgb(var(--color-primary-500)/<alpha-value>)",
+          600: "rgb(var(--color-primary-600)/<alpha-value>)",
+          700: "rgb(var(--color-primary-700)/<alpha-value>)",
+          800: "rgb(var(--color-primary-800)/<alpha-value>)",
+          900: "rgb(var(--color-primary-900)/<alpha-value>)",
+          950: "rgb(var(--color-primary-950)/<alpha-value>)",
+        },
         primary: {
+          DEFAULT: "rgb(var(--primary, 103 130 203) / <alpha-value>)",
+          foreground: "rgb(var(--primary-foreground, 250 250 250) / <alpha-value>)",
           0: "rgb(var(--color-primary-0)/<alpha-value>)",
           50: "rgb(var(--color-primary-50)/<alpha-value>)",
           100: "rgb(var(--color-primary-100)/<alpha-value>)",
@@ -189,6 +227,7 @@ module.exports = {
           950: "rgb(var(--color-outline-950)/<alpha-value>)",
         },
         background: {
+          DEFAULT: "rgb(var(--background, 255 255 255) / <alpha-value>)",
           0: "rgb(var(--color-background-0)/<alpha-value>)",
           50: "rgb(var(--color-background-50)/<alpha-value>)",
           100: "rgb(var(--color-background-100)/<alpha-value>)",

--- a/client/theme/tokens.ts
+++ b/client/theme/tokens.ts
@@ -1,0 +1,123 @@
+/**
+ * Single source of truth for semantic theme tokens (CSS variables).
+ *
+ * Architecture:
+ * - Brand palette hex scales → tailwind.config.js (indigoscale, redscale, …)
+ * - Semantic tokens (--primary, --destructive, …) → this file
+ * - Runtime injection → components/GluestackUIProvider.tsx (NativeWind vars())
+ * - Tailwind class resolution → tailwind.config.js fallbacks (must match values here)
+ * - App button API → components/button.tsx (action prop; overrides generated hovers)
+ *
+ * Do NOT add duplicate CSS files or post-build patches on generated ui/ components.
+ */
+
+export type ThemeMode = "light" | "dark";
+
+export type ThemeTokens = Record<`--${string}`, string>;
+
+export const lightTheme: ThemeTokens = {
+  /* Semantic tokens (shadcn / gluestack components) */
+  "--primary": "103 130 203",
+  "--primary-foreground": "250 250 250",
+  "--secondary": "133 42 213",
+  "--secondary-foreground": "250 250 250",
+  "--destructive": "213 69 42",
+  "--background": "255 255 255",
+  "--foreground": "23 23 23",
+  "--card": "255 255 255",
+  "--popover": "255 255 255",
+  "--popover-foreground": "10 10 10",
+  "--border": "229 229 229",
+  "--input": "229 229 229",
+  "--muted": "245 245 245",
+  "--muted-foreground": "115 115 115",
+  "--accent": "245 245 245",
+  "--accent-foreground": "23 23 23",
+  "--ring": "103 130 203",
+
+  /* Gluestack utility scales used by generated components / app classes */
+  "--color-background-0": "255 255 255",
+  "--color-background-50": "251 251 251",
+  "--color-background-100": "245 245 245",
+  "--color-background-200": "240 240 240",
+  "--color-background-300": "229 229 229",
+  "--color-background-400": "212 212 212",
+  "--color-background-500": "163 163 163",
+  "--color-background-600": "115 115 115",
+  "--color-background-700": "82 82 82",
+  "--color-background-800": "38 38 38",
+  "--color-background-900": "23 23 23",
+  "--color-background-950": "10 10 10",
+  "--color-background-error": "252 213 204",
+  "--color-background-warning": "250 245 201",
+  "--color-background-success": "219 250 211",
+  "--color-background-info": "208 227 248",
+  "--color-background-muted": "245 245 245",
+  "--color-typography-0": "255 255 255",
+  "--color-typography-50": "251 251 251",
+  "--color-typography-100": "245 245 245",
+  "--color-typography-200": "229 229 229",
+  "--color-typography-300": "212 212 212",
+  "--color-typography-400": "163 163 163",
+  "--color-typography-500": "115 115 115",
+  "--color-typography-600": "82 82 82",
+  "--color-typography-700": "64 64 64",
+  "--color-typography-800": "38 38 38",
+  "--color-typography-900": "23 23 23",
+  "--color-typography-950": "10 10 10",
+};
+
+export const darkTheme: ThemeTokens = {
+  "--primary": "103 130 203",
+  "--primary-foreground": "10 10 10",
+  "--secondary": "133 42 213",
+  "--secondary-foreground": "10 10 10",
+  "--destructive": "213 69 42",
+  "--background": "10 10 10",
+  "--foreground": "250 250 250",
+  "--card": "38 38 38",
+  "--popover": "38 38 38",
+  "--popover-foreground": "250 250 250",
+  "--border": "82 82 82",
+  "--input": "82 82 82",
+  "--muted": "64 64 64",
+  "--muted-foreground": "161 161 161",
+  "--accent": "64 64 64",
+  "--accent-foreground": "250 250 250",
+  "--ring": "103 130 203",
+
+  "--color-background-0": "10 10 10",
+  "--color-background-50": "23 23 23",
+  "--color-background-100": "38 38 38",
+  "--color-background-200": "64 64 64",
+  "--color-background-300": "82 82 82",
+  "--color-background-400": "115 115 115",
+  "--color-background-500": "163 163 163",
+  "--color-background-600": "212 212 212",
+  "--color-background-700": "229 229 229",
+  "--color-background-800": "240 240 240",
+  "--color-background-900": "245 245 245",
+  "--color-background-950": "251 251 251",
+  "--color-background-error": "80 26 16",
+  "--color-background-warning": "80 74 16",
+  "--color-background-success": "36 80 16",
+  "--color-background-info": "10 50 86",
+  "--color-background-muted": "64 64 64",
+  "--color-typography-0": "10 10 10",
+  "--color-typography-50": "23 23 23",
+  "--color-typography-100": "38 38 38",
+  "--color-typography-200": "64 64 64",
+  "--color-typography-300": "82 82 82",
+  "--color-typography-400": "115 115 115",
+  "--color-typography-500": "163 163 163",
+  "--color-typography-600": "212 212 212",
+  "--color-typography-700": "229 229 229",
+  "--color-typography-800": "240 240 240",
+  "--color-typography-900": "245 245 245",
+  "--color-typography-950": "251 251 251",
+};
+
+export const themeTokens: Record<ThemeMode, ThemeTokens> = {
+  light: lightTheme,
+  dark: darkTheme,
+};


### PR DESCRIPTION
- `tokens.ts` — single committed source for semantic CSS vars

- `GluestackUIProvider.tsx` — injects tokens via NativeWind vars()
- new button wrapper component to wrap-over the uncommitted button gluestack component: 
- `button.tsx` — maps action → variant + hover overrides that beat generated styles:

`negative` → solid red with destructive/90 hover
`negative` + `outline` → red border with destructive/10 hover
`primary` + `outline` + `active` → nav tab styling (Header migrated)
`secondary` → neutral outline hover via accent, not fighting custom colors
